### PR TITLE
make ElasticRefreshHeader.control public

### DIFF
--- a/Source/Classes/ElasticRefreshHeader.swift
+++ b/Source/Classes/ElasticRefreshHeader.swift
@@ -10,7 +10,7 @@ import Foundation
 import UIKit
 
 open class ElasticRefreshHeader: UIView,RefreshableHeader {
-    let control:ElasticRefreshControl
+    public let control:ElasticRefreshControl
     public let textLabel:UILabel = UILabel(frame: CGRect(x: 0,y: 0,width: 120,height: 40))
     public let imageView:UIImageView = UIImageView(frame: CGRect.zero)
     fileprivate var textDic = [RefreshKitHeaderText:String]()


### PR DESCRIPTION
以允许用户自定 `ElasticRefreshHeader.control.spinner.style`

为了 解决  [V2EX] (https://github.com/aidevjoe/V2EX) 在 **夜间/纯黑** 模式下刷新时 `UIActivityIndicatorView` **不明显/不显示** 的问题